### PR TITLE
Various updates and cleanups

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -7,8 +7,9 @@ metadata:
     chart: {{ template "phpldapadmin.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.extraLabels }}
-{{ toYaml .Values.extraLabels | indent 4 }}
-{{- end }}
+    {{- if .Values.extraLabels }}
+      {{- toYaml .Values.extraLabels | nindent 4 }}
+    {{- end }}
 data:
-{{ toYaml .Values.env | indent 2 }}
+  config.yaml: |
+    {{- .Values.config | nindent 4 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -29,24 +29,32 @@ spec:
         - name: http
           containerPort: 80
           protocol: TCP
-        envFrom:
-        - configMapRef:
-            name: {{ template "phpldapadmin.fullname" . }}
+        volumeMounts:
+          - name: config
+            mountPath: /container/environment/01-custom
         livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 12 }}
+          {{- toYaml .Values.livenessProbe | nindent 10 }}
         readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 12 }}
+          {{- toYaml .Values.readinessProbe | nindent 10 }}
         resources:
-{{ toYaml .Values.resources | indent 12 }}
-    {{- with .Values.nodeSelector }}
+          {{- toYaml .Values.resources | nindent 10 }}
+
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "phpldapadmin.fullname" . }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "phpldapadmin.fullname" . -}}
-{{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+{{- $defaultPath := .Values.ingress.defaultPath -}}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -10,10 +10,12 @@ metadata:
     chart: {{ template "phpldapadmin.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+
 {{- with .Values.ingress.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
 {{- end }}
+
 spec:
 {{- if .Values.ingress.tls }}
   tls:
@@ -25,14 +27,18 @@ spec:
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
+
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ .host }}
       http:
         paths:
-          - path: {{ $ingressPath }}
+          - path: {{ default $defaultPath .path | squote }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -52,10 +52,11 @@ service:
 ingress:
   enabled: false
   annotations: {}
-  path: /
+  defaultPath: '/'
   ## Ingress Host
   # hosts:
-  # - phpldapadmin.example.org
+  # - host: phpldapadmin.example.org
+  #   path: / ## Defaults to ingress.defaultPath
   #
   tls: []
   # tls:

--- a/values.yaml
+++ b/values.yaml
@@ -4,10 +4,10 @@
 # Declare variables to be passed into your templates.
 
 ## TODO: add this in the deployment.yaml
-env:
+config: |
   # PHPLDAPADMIN_LDAP_HOSTS: ...
-  PHPLDAPADMIN_HTTPS: "false"
-  PHPLDAPADMIN_TRUST_PROXY_SSL: "true"
+  PHPLDAPADMIN_HTTPS: false
+  PHPLDAPADMIN_TRUST_PROXY_SSL: true
 
 ## Number of phpLDAPadmin images
 replicaCount: 1
@@ -16,7 +16,7 @@ replicaCount: 1
 ##
 image:
   repository: osixia/phpldapadmin
-  tag: 0.7.1
+  tag: 0.9.0
   pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
I did some updates and cleanups:
- Update image version from 0.7.1 to 0.9.0
- Update Ingress definition to use the new API; the beta-api will no longer be supported in newer version and is currently deprecated
- Cleanup templates using `nindent` vs `indent`
- Mounting the configuration of LdapAdmin as a file, instead of putting the configuration in environment variables. This was more stable in my experience
- Added flexibility to ingress hosts definition by allowing a custom path per host.